### PR TITLE
Specify the presets in webpack.config.js itself

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,9 @@ module.exports = {
                     exclude: /(node_modules\/[a-z]|bower_components)/, //TODO-IAUX make this exclusion more precise
                     use: {
                         loader: 'babel-loader',
+                        options: {
+                            presets: ['@babel/preset-react', '@babel/preset-env'],
+                        }
                     }
                 }
             ]


### PR DESCRIPTION
The presets for adding support for JSX, i.e `"preset-react"` was not working from `.babelrc` file. Therefore, specifying the presets and webpack config itself.

**Testing**
- Pull the branch
- `yarn run build`